### PR TITLE
ensure dependency retrieval uses the same sbt as build

### DIFF
--- a/lib/sbt-derivation.nix
+++ b/lib/sbt-derivation.nix
@@ -41,7 +41,7 @@
     COURSIER_CACHE = "project/.coursier";
   };
 
-  dependencies = (callPackage ./dependencies.nix {}) {
+  dependencies = (callPackage ./dependencies.nix { inherit sbt; }) {
     inherit src patches nativeBuildInputs sbtEnv;
 
     namePrefix = "${pname}-sbt-dependencies";


### PR DESCRIPTION
If the sbt passed to mkSbtDerivation is overridden (e.g. to use a different Java version), then `sbt` in sbt-derivation.nix won't match `sbt` in dependencies.nix because callPackage won't see the overridden version. Inherit `sbt` during the callPackage to avoid this problem.