### PR TITLE
move dependency dir out of project directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ If you're not ready to migrate, the previous version is kept in a branch called 
 
 ### Changed behaviour
 - `postConfigure` will now run after extracting the dependencies (was running before). The whole configure phase is used to extract the dependencies.
-- The dependencies are no longer stored in a `.nix` directory, but rather in the default locations provided by sbt in `--no-share` mode.
+- The dependencies are no longer stored in a `.nix` directory, but rather in a temporary global directory mirroring the structure used by sbt in `--no-share` mode.
 - `overrideDepsAttrs` now takes two parameters, `final` and `prev`, instead of just `prev`.
 
 ### New options

--- a/lib/archival-strategies.nix
+++ b/lib/archival-strategies.nix
@@ -9,7 +9,7 @@
     fileExtension = "";
     packerFragment = ''
       mkdir -p $out
-      cp -ar project/{.sbtboot,.boot,.ivy,.coursier} $out
+      cp -ar $SBT_DEPS/project/. $out
     '';
   };
 in {
@@ -20,7 +20,7 @@ in {
     packerFragment = ''
       tar --owner=0 --group=0 --numeric-owner --format=gnu \
         --sort=name --mtime="@$SOURCE_DATE_EPOCH" \
-        -C project -cf "$out" .sbtboot .boot .ivy .coursier
+        -C $SBT_DEPS/project -cf $out .
     '';
     extractorFragment = deps: ''
       tar -C "$target/project" -xpf ${deps}
@@ -34,7 +34,7 @@ in {
       tar --owner=0 --group=0 --numeric-owner --format=gnu \
         --sort=name --mtime="@$SOURCE_DATE_EPOCH" \
         -I 'zstd -c --fast=3 -' \
-        -C project -cf "$out" .sbtboot .boot .ivy .coursier
+        -C $SBT_DEPS/project -cf $out .
     '';
     extractorFragment = deps: ''
       tar -I zstd -C "$target/project" -xpf ${deps}
@@ -53,7 +53,6 @@ in {
     // {
       nativeBuildInputs = [stow];
       extractorFragment = deps: ''
-        mkdir -p "$target/project"
         stow -t "$target/project" -d ${builtins.dirOf deps} --no-folding ${builtins.baseNameOf deps}
       '';
     };


### PR DESCRIPTION
This means that sbt can be used anywhere in the source tree and will always be able to find its dependencies.

I ran the whole test suite and my own projects without issues. I also cleaned up some of the archive strategies.

Closes #11.