### PR TITLE
propagate prePatch/postPatch into dependency derivation

### DIFF
--- a/lib/dependencies.nix
+++ b/lib/dependencies.nix
@@ -16,6 +16,8 @@
   sbtEnvSetupCmds,
   src,
   patches ? [],
+  prePatch ? "",
+  postPatch ? "",
   sha256,
   warmupCommand,
   nativeBuildInputs ? [],
@@ -26,7 +28,7 @@
   archivalStrategy = (callPackage ./archival-strategies.nix {}).${args.archivalStrategy};
 
   mkAttrs = drv: {
-    inherit src patches;
+    inherit src patches prePatch postPatch;
 
     name = namePrefix + archivalStrategy.fileExtension;
 

--- a/lib/sbt-derivation.nix
+++ b/lib/sbt-derivation.nix
@@ -10,6 +10,8 @@
   nativeBuildInputs ? [],
   passthru ? {},
   patches ? [],
+  prePatch ? "",
+  postPatch ? "",
   #
   # A function [final => prev => attrset] to override the dependencies derivation
   overrideDepsAttrs ? (_: _: {}),
@@ -47,7 +49,7 @@
   '';
 
   dependencies = (callPackage ./dependencies.nix {}) {
-    inherit src patches nativeBuildInputs sbtEnvSetupCmds;
+    inherit src patches nativeBuildInputs sbtEnvSetupCmds prePatch postPatch;
 
     namePrefix = "${pname}-sbt-dependencies";
     sha256 = depsSha256;


### PR DESCRIPTION
Since the src and patches attributes are propagated, it is unexpected that the prePatch and postPatch hooks are not. This will make it easier to perform substitutions on the src which might depend on other Nix variables, without needing to duplicate them in both the dependency and original derivations.